### PR TITLE
Power consumption optimizations

### DIFF
--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -5,7 +5,6 @@ import {
   calibrateIMU,
   onConnectRequest,
   setCoeffs,
-  Orientation,
   Config,
   SensorData,
   Coeffs,
@@ -226,14 +225,7 @@ function EstimatesSection({ connected, sensorData }: EstimatesSectionProps) {
 }
 
 function App() {
-  const [orientation, setOrientation] = useState<Orientation>({
-    quaternion: new Quaternion(),
-    eulerAngles: {
-      psi: 0,
-      theta: 0,
-      phi: 0,
-    },
-  });
+  const orientation = useState<Quaternion>(new Quaternion());
 
   const [sensorData, setSensorData] = useState<SensorData>({
     angle: 0,
@@ -270,15 +262,6 @@ function App() {
 
   const onConfig = useCallback(
     (config: Config) => {
-      // console.log(
-      //   "Version",
-      //   config.version,
-      //   "hasImu",
-      //   config.hasIMUOffsets,
-      //   "hasCoeff",
-      //   config.hasCoeffs,
-      //   config.coeffs
-      // );
       setConfig(config);
     },
     [setConfig]
@@ -286,13 +269,7 @@ function App() {
 
   // @ts-ignore
   const onConnectClickCB = useCallback(
-    onConnectRequest(
-      onConnect,
-      onDisconnect,
-      setOrientation,
-      onSensorData,
-      onConfig
-    ),
+    onConnectRequest(onConnect, onDisconnect, onSensorData, onConfig),
     []
   );
 
@@ -306,7 +283,7 @@ function App() {
           <EstimatesSection connected={connected} sensorData={sensorData} />
         </div>
         <div className="Container-right">
-          <Model orientation={orientation.quaternion} />
+          <Model orientation={orientation[0]} />
         </div>
       </div>
     </div>

--- a/clients/web/src/ble.ts
+++ b/clients/web/src/ble.ts
@@ -1,16 +1,11 @@
-import { Quaternion } from "three";
-
 const kUARTServiceUUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
 // const kUARTTXCharUUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e";
 const kSensorServiceUUID = "9b7d5c6f-a8ca-4080-9290-d4afb5ac64a3";
 const kSensorCharacteristicUUID = "527d0f9b-db66-48c5-9089-071e1a795b6f";
-const kOrientationCharacteristicUUID = "caf0797d-71d3-4ae5-b2a6-67c18f70afa6";
 const kConfigServiceUUID = "e94989ee-7b22-4b34-b71d-a33459aea9ae";
 const kConfigCharacteristicUUID = "e65785ce-955b-42aa-95a2-b7d96806d3da";
 
 let configChar: BluetoothRemoteGATTCharacteristic | null = null;
-// let sensorChar: BluetoothRemoteGATTCharacteristic | null = null;
-// let orientationChar: BluetoothRemoteGATTCharacteristic | null = null;
 
 export type Callback = () => void;
 
@@ -40,45 +35,12 @@ export type Config = {
 
 export type onConfig = (config: Config) => void;
 
-export type Orientation = {
-  quaternion: Quaternion;
-  eulerAngles: {
-    psi: number;
-    theta: number;
-    phi: number;
-  };
-};
-
-export type onOrientation = (orientation: Orientation) => void;
-
 function onConnectRequest(
   onConnect: Callback,
   onDisconnect: Callback,
-  onOrientation: onOrientation,
   onSensor: onSensor,
   onConfig: onConfig
 ) {
-  function onOrientationEvent(event: any) {
-    const characteristic = event.target;
-    const data: DataView = characteristic.value;
-    return onOrientationData(data);
-  }
-
-  function onOrientationData(data: DataView) {
-    const w = data.getInt16(0, true) / 1000.0;
-    const x = data.getInt16(2, true) / 1000.0;
-    const y = data.getInt16(4, true) / 1000.0;
-    const z = data.getInt16(6, true) / 1000.0;
-    onOrientation({
-      quaternion: new Quaternion(x, y, z, w),
-      eulerAngles: {
-        psi: data.getInt16(8, true) / 100.0,
-        theta: data.getInt16(10, true) / 100.0,
-        phi: data.getInt16(12, true) / 100.0,
-      },
-    });
-  }
-
   function onSensorEvent(event: any) {
     const characteristic = event.target;
     const data: DataView = characteristic.value;
@@ -129,21 +91,6 @@ function onConnectRequest(
     });
   }
 
-  function handleOrientationChar(
-    characteristic: BluetoothRemoteGATTCharacteristic
-  ) {
-    // orientationChar = characteristic;
-    return Promise.all([
-      characteristic.readValue().then(onOrientationData),
-      characteristic.startNotifications().then((char) => {
-        characteristic.addEventListener(
-          "characteristicvaluechanged",
-          onOrientationEvent
-        );
-      }),
-    ]);
-  }
-
   function handleSensorChar(characteristic: BluetoothRemoteGATTCharacteristic) {
     // sensorChar = characteristic;
     return Promise.all([
@@ -159,9 +106,6 @@ function onConnectRequest(
 
   function handleSensorService(service: BluetoothRemoteGATTService) {
     return Promise.all([
-      // service
-      //   .getCharacteristic(kOrientationCharacteristicUUID)
-      //   .then(handleOrientationChar),
       service
         .getCharacteristic(kSensorCharacteristicUUID)
         .then(handleSensorChar),
@@ -206,8 +150,6 @@ function onConnectRequest(
       .then((device) => {
         device.addEventListener("gattserverdisconnected", function (ev) {
           configChar = null;
-          // sensorChar = null;
-          // orientationChar = null;
           onDisconnect();
         });
         return device.gatt!.connect();

--- a/clients/web/src/ble.ts
+++ b/clients/web/src/ble.ts
@@ -159,9 +159,9 @@ function onConnectRequest(
 
   function handleSensorService(service: BluetoothRemoteGATTService) {
     return Promise.all([
-      service
-        .getCharacteristic(kOrientationCharacteristicUUID)
-        .then(handleOrientationChar),
+      // service
+      //   .getCharacteristic(kOrientationCharacteristicUUID)
+      //   .then(handleOrientationChar),
       service
         .getCharacteristic(kSensorCharacteristicUUID)
         .then(handleSensorChar),

--- a/code/sugarboat/.vscode/extensions.json
+++ b/code/sugarboat/.vscode/extensions.json
@@ -3,5 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/code/sugarboat/.vscode/settings.json
+++ b/code/sugarboat/.vscode/settings.json
@@ -9,6 +9,7 @@
     "iosfwd": "cpp",
     "new": "cpp",
     "ostream": "cpp",
-    "streambuf": "cpp"
+    "streambuf": "cpp",
+    "cmath": "cpp"
   }
 }

--- a/code/sugarboat/lib/sugarboat/sugarboat/ble.cpp
+++ b/code/sugarboat/lib/sugarboat/sugarboat/ble.cpp
@@ -107,7 +107,8 @@ bool BLE::StartAdv() {
   // Advertisement interval in units of 625 us. For estimating impact in battery
   // life, use
   // https://devzone.nordicsemi.com/nordic/power/w/opp/2/online-power-profiler-for-ble.
-  Bluefruit.Advertising.setInterval(32, 244);
+  // Bluefruit.Advertising.setInterval(32, 244);
+  Bluefruit.Advertising.setInterval(32, 3200);
   Bluefruit.Advertising.setFastTimeout(1);
   Bluefruit.Advertising.start(0);
 

--- a/code/sugarboat/lib/sugarboat/sugarboat/ble.cpp
+++ b/code/sugarboat/lib/sugarboat/sugarboat/ble.cpp
@@ -46,11 +46,14 @@ bool BLE::Init(Config& config, IMU& imu) {
   Bluefruit.setName("sugarboat");
   Bluefruit.Periph.setConnectCallback(ConnCallback);
   Bluefruit.Periph.setDisconnectCallback(DisconnCallback);
+  Bluefruit.Periph.setConnInterval(800, 1600);
+  // Bluefruit.Periph.setConnIntervalMS(1000, 2000);
+  // Bluefruit.Central.setConnIntervalMS(1000, 2000);
 
-  if (bleuart_.begin()) {
-    Serial.println("[ble] Error initializing BLE UART service");
-    return false;
-  }
+  // if (bleuart_.begin()) {
+  //   Serial.println("[ble] Error initializing BLE UART service");
+  //   return false;
+  // }
 
   // Init config service & characteristic.
   if (cfg_service_.begin()) {
@@ -73,12 +76,14 @@ bool BLE::Init(Config& config, IMU& imu) {
     return false;
   }
   sensor_char_.setProperties(CHR_PROPS_READ | CHR_PROPS_NOTIFY);
+  // sensor_char_.setProperties(CHR_PROPS_READ);
   sensor_char_.setPermission(SECMODE_OPEN, SECMODE_OPEN);
   if (sensor_char_.begin()) {
     Serial.println("[ble] Error initializing BLE sensor characteristic");
     return false;
   }
   orientation_char_.setProperties(CHR_PROPS_READ | CHR_PROPS_NOTIFY);
+  // orientation_char_.setProperties(CHR_PROPS_READ);
   orientation_char_.setPermission(SECMODE_OPEN, SECMODE_OPEN);
   if (orientation_char_.begin()) {
     Serial.println("[ble] Error initializing BLE orientation characteristic");
@@ -249,6 +254,14 @@ void BLE::ConnCallback(uint16_t conn_handle) {
   if (++ble.n_conns_ < kMaxConnections) {
     Bluefruit.Advertising.start(0);
   }
+
+  BLEConnection* conn = Bluefruit.Connection(conn_handle);
+  uint16_t conn_int = conn->getConnectionInterval();
+  Serial.printf("[ble] Connection interval: %d\n", conn_int);
+
+  // Request the connecting central to change the connection
+  conn->requestConnectionParameter(300);
+
   Serial.printf("[ble] Connection callback. #clients: %d\n", ble.n_conns_);
 }
 

--- a/code/sugarboat/lib/sugarboat/sugarboat/ble.h
+++ b/code/sugarboat/lib/sugarboat/sugarboat/ble.h
@@ -13,8 +13,6 @@ namespace {
 constexpr char kSensorServiceUUID[] = "9b7d5c6f-a8ca-4080-9290-d4afb5ac64a3";
 constexpr char kSensorCharacteristicUUID[] =
     "527d0f9b-db66-48c5-9089-071e1a795b6f";
-constexpr char kOrientationCharacteristicUUID[] =
-    "caf0797d-71d3-4ae5-b2a6-67c18f70afa6";
 constexpr char kConfigServiceUUID[] = "e94989ee-7b22-4b34-b71d-a33459aea9ae";
 constexpr char kConfigCharacteristicUUID[] =
     "e65785ce-955b-42aa-95a2-b7d96806d3da";
@@ -45,15 +43,12 @@ class BLE {
 
   bool InjectSensorData(const SensorData& sensor_data);
 
-  bool InjectOrientationData(const IMU::Orientation& orientation);
-
  private:
   BLE()
       : cfg_service_(kConfigServiceUUID),
         cfg_char_(kConfigCharacteristicUUID),
         sensor_service_(kSensorServiceUUID),
-        sensor_char_(kSensorCharacteristicUUID),
-        orientation_char_(kOrientationCharacteristicUUID) {}
+        sensor_char_(kSensorCharacteristicUUID) {}
 
   static void CfgCharWriteCallback(uint16_t conn_hdl, BLECharacteristic* chr,
                                    uint8_t* data, uint16_t len);
@@ -70,7 +65,6 @@ class BLE {
   BLECharacteristic cfg_char_;
   BLEService sensor_service_;
   BLECharacteristic sensor_char_;
-  BLECharacteristic orientation_char_;
 };
 
 }  // namespace sugarboat

--- a/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.cpp
+++ b/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.cpp
@@ -5,7 +5,61 @@
 #include "sugarboat/config.h"
 
 namespace sugarboat {
-namespace {}  // namespace
+namespace {
+
+int InitMPULowPower(MPU6050& mpu) {
+  // Disable DMP.
+  mpu.setDMPEnabled(false);
+
+  // Enable FIFO.
+  mpu.setFIFOEnabled(true);
+
+  // mpu_.setWakeCycleEnabled(true);
+  // 5 Hz accelerometer wakeup frequency - only applies to low power mode.
+  // mpu_.setWakeFrequency(0x01);
+  // mpu_.setRate(0x1);
+  // Use internal clock source. Requirement for low power mode.
+  // mpu_.setClockSource(0x00);
+
+  // Disable temp sensor.
+  mpu.setTempSensorEnabled(false);
+
+  // Disable gyro.
+  mpu.setStandbyXGyroEnabled(true);
+  mpu.setStandbyYGyroEnabled(true);
+  mpu.setStandbyZGyroEnabled(true);
+
+  // Disable gyro in FIFO.
+  mpu.setXGyroFIFOEnabled(false);
+  mpu.setYGyroFIFOEnabled(false);
+  mpu.setZGyroFIFOEnabled(false);
+
+  // Enable accel in FIFO.
+  mpu.setAccelFIFOEnabled(true);
+
+  // Accel wake up frequency (only in low power mode).
+  mpu.setWakeFrequency(0x00);
+
+  // Use internal clock source. Requirement for low power mode?
+  mpu.setClockSource(0x0);
+
+  return 0;
+}
+
+int InitMPUDMPMode(MPU6050& mpu) {
+  // The MPU6050's mysterious DMP processor needs its firmware
+  // written every time it's powered on.
+  if (mpu.dmpInitialize()) {
+    Serial.printf("[imu] Failed to initialize DMP\n");
+    return 1;
+  }
+
+  mpu.setIntDataReadyEnabled(true);
+  mpu.setDMPEnabled(true);
+
+  return 0;
+}
+}  // namespace
 
 int IMU::Init(const Offsets& offsets) {
   pinMode(FLT_MPU_INTERRUPT_PIN, INPUT);
@@ -18,27 +72,16 @@ int IMU::Init(const Offsets& offsets) {
 
   // The MPU6050's mysterious DMP processor needs its firmware
   // written every time it's powered on.
-  if (mpu_.dmpInitialize()) {
-    Serial.printf("[imu] Failed to initialize DMP\n");
-    return 1;
-  }
+  // if (mpu_.dmpInitialize()) {
+  //   Serial.printf("[imu] Failed to initialize DMP\n");
+  //   return 1;
+  // }
 
   // mpu_.setIntDataReadyEnabled(true);
 
-  mpu_.setDMPEnabled(true);
+  // mpu_.setDMPEnabled(true);
 
-  // mpu_.setXAccelOffset(0);
-  // mpu_.setYAccelOffset(0);
-  // mpu_.setZAccelOffset(0);
-  // mpu_.setXGyroOffset(0);
-  // mpu_.setYGyroOffset(0);
-  // mpu_.setZGyroOffset(0);
-  // mpu_.setXAccelOffset(-1743);
-  // mpu_.setYAccelOffset(719);
-  // mpu_.setZAccelOffset(1101);
-  // mpu_.setXGyroOffset(100);
-  // mpu_.setYGyroOffset(60);
-  // mpu_.setZGyroOffset(1);
+  // mpu_.setDMPEnabled(false);
 
   mpu_.setXAccelOffset(offsets.accel_x);
   mpu_.setYAccelOffset(offsets.accel_y);
@@ -47,9 +90,8 @@ int IMU::Init(const Offsets& offsets) {
   mpu_.setYGyroOffset(offsets.gyro_y);
   mpu_.setZGyroOffset(offsets.gyro_z);
 
-  // mpu_.setWakeCycleEnabled(true);
-  // mpu_.setWakeFrequency(0x01);
-  mpu_.setRate(0x1);
+  // InitMPULowPower(mpu_);
+  InitMPUDMPMode(mpu_);
 
   Serial.printf("[imu] Initialized!\n");
   return 0;

--- a/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.h
+++ b/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.h
@@ -18,24 +18,6 @@ class IMU {
     int16_t gyro_z = 0;
   };
 
-  struct IMUQuaternion {
-    float w;
-    float x;
-    float y;
-    float z;
-  };
-
-  struct EulerAngles {
-    float psi;
-    float theta;
-    float phi;
-  };
-
-  struct Orientation {
-    IMUQuaternion quaternion;
-    EulerAngles euler_angles;
-  };
-
   IMU() {}
   IMU(const IMU &other) = delete;
   IMU &operator=(const IMU &other) = delete;
@@ -46,12 +28,9 @@ class IMU {
   void WakeUp();
   Offsets Calibrate();
   float GetTilt();
-  Orientation GetOrientation();
 
  private:
   MPU6050 mpu_;
-  uint8_t fifo_buffer_[64];
-  Quaternion quaternion_;
 };
 }  // namespace sugarboat
 #endif  // _SUGARBOAT_MPU6050_H_

--- a/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.h
+++ b/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.h
@@ -48,6 +48,19 @@ class IMU {
   float GetTilt();
   Orientation GetOrientation();
 
+  void Loop() {
+    int fifo_count = mpu_.getFIFOCount();
+    Serial.printf("[mpu] FIFO count: %d\n", fifo_count);
+    int16_t x, y, z;
+    mpu_.getAcceleration(&x, &y, &z);
+    float angle = 180.0f * atan2(y, z) / PI;
+    Serial.printf("angle: %.2f, accel x: %d, y: %d, z: %d\n", angle, x, y, z);
+    // for (int i = 0; i < fifo_count; i++) {
+    //   uint8_t fifo_byte = mpu_.getFIFOByte();
+    //   Serial.printf("\tFIFO BYTE: 0x%02x\n", fifo_byte);
+    // }
+  }
+
  private:
   MPU6050 mpu_;
   uint8_t fifo_buffer_[64];

--- a/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.h
+++ b/code/sugarboat/lib/sugarboat/sugarboat/mpu6050.h
@@ -48,19 +48,6 @@ class IMU {
   float GetTilt();
   Orientation GetOrientation();
 
-  void Loop() {
-    int fifo_count = mpu_.getFIFOCount();
-    Serial.printf("[mpu] FIFO count: %d\n", fifo_count);
-    int16_t x, y, z;
-    mpu_.getAcceleration(&x, &y, &z);
-    float angle = 180.0f * atan2(y, z) / PI;
-    Serial.printf("angle: %.2f, accel x: %d, y: %d, z: %d\n", angle, x, y, z);
-    // for (int i = 0; i < fifo_count; i++) {
-    //   uint8_t fifo_byte = mpu_.getFIFOByte();
-    //   Serial.printf("\tFIFO BYTE: 0x%02x\n", fifo_byte);
-    // }
-  }
-
  private:
   MPU6050 mpu_;
   uint8_t fifo_buffer_[64];

--- a/code/sugarboat/src/main.cpp
+++ b/code/sugarboat/src/main.cpp
@@ -23,9 +23,15 @@ Adafruit_SHT31 sht31 = Adafruit_SHT31();
 #define SGRBT_SCL_PIN 10
 #define SGRBT_BAT_SEN_PIN 18
 
+// Baseline: 17 uA
+// With accel in low power mode: 30 uA
+// With BLE + accel lo po: 40 uA
+
 void setup() {
+  // Uses ~40uA!
+  // pinMode(SGRBT_BAT_SEN_PIN, INPUT);
+
   pinMode(LED_BUILTIN2, OUTPUT);
-  pinMode(SGRBT_BAT_SEN_PIN, INPUT);
 
   digitalWrite(LED_BUILTIN2, HIGH);
 
@@ -74,24 +80,25 @@ void loop() {
   bool is_realtime = config.GetRealtimeRun();
 
   imu.WakeUp();
-  if (!is_realtime) {
-    Serial.printf("[main] Waking up IMU...\n");
-    // TODO: Better strategy for waiting IMU values to converge.
-    if (config.WaitForConfigChangeOrDelay(10000)) {
-      return;
-    }
-  }
+  // // if (!is_realtime) {
+  // //   Serial.printf("[main] Waking up IMU...\n");
+  // //   // TODO: Better strategy for waiting IMU values to converge.
+  // //   if (config.WaitForConfigChangeOrDelay(10000)) {
+  // //     return;
+  // //   }
+  // // }
 
-  sugarboat::IMU::Orientation orientation = imu.GetOrientation();
+  // // sugarboat::IMU::Orientation orientation = imu.GetOrientation();
   sensor_data.tilt_degrees = imu.GetTilt();
-  Serial.printf("[main] Tilt: %.2f\n", sensor_data.tilt_degrees);
+  // // Serial.printf("[main] Tilt: %.2f\n", sensor_data.tilt_degrees);
 
-  if (!is_realtime) {
-    Serial.printf("[main] Sleeping IMU...\n");
-    imu.Sleep();
-  }
+  // // if (!is_realtime) {
+  // //   Serial.printf("[main] Sleeping IMU...\n");
+  // //   imu.Sleep();
+  // // }
 
-  ble.InjectOrientationData(orientation);
+  // // ble.InjectOrientationData(orientation);
+  imu.Sleep();
 
   float batt_v = 2 * 3.6f * analogRead(SGRBT_BAT_SEN_PIN) / 1024.0f;
 
@@ -117,11 +124,4 @@ void loop() {
     Serial.printf("[main] Delaying...\n");
     config.WaitForConfigChangeOrDelay(5000);
   }
-
-  // imu.Loop();
-  // imu.Sleep();
-  // delay(5000);
-  // imu.WakeUp();
-  // delay(5000);
-  // Serial.println("Here");
 }

--- a/code/sugarboat/src/main.cpp
+++ b/code/sugarboat/src/main.cpp
@@ -37,7 +37,7 @@ void setup() {
   // Uncomment to block the execution until the USB serial port is open.
   // while (!Serial)
   //   ;
-  delay(1000);
+  delay(500);
 
   if (!sht30.Init()) {
     Serial.println("[main] Error initializing SHT30");
@@ -63,7 +63,7 @@ void setup() {
     while (true)
       ;
   }
-  delay(500);
+  delay(100);
   ble.StartAdv();
 
   digitalWrite(LED_BUILTIN2, LOW);
@@ -117,4 +117,11 @@ void loop() {
     Serial.printf("[main] Delaying...\n");
     config.WaitForConfigChangeOrDelay(5000);
   }
+
+  // imu.Loop();
+  // imu.Sleep();
+  // delay(5000);
+  // imu.WakeUp();
+  // delay(5000);
+  // Serial.println("Here");
 }

--- a/code/sugarboat/src/main.cpp
+++ b/code/sugarboat/src/main.cpp
@@ -18,7 +18,7 @@ sugarboat::SHT30 sht30;
 
 Adafruit_SHT31 sht31 = Adafruit_SHT31();
 
-#define LED_BUILTIN2 16
+#define SGRBT_LED_PIN 16
 #define SGRBT_SDA_PIN 6
 #define SGRBT_SCL_PIN 10
 #define SGRBT_BAT_SEN_PIN 18
@@ -31,9 +31,9 @@ void setup() {
   // Uses ~40uA!
   // pinMode(SGRBT_BAT_SEN_PIN, INPUT);
 
-  pinMode(LED_BUILTIN2, OUTPUT);
+  pinMode(SGRBT_LED_PIN, OUTPUT);
 
-  digitalWrite(LED_BUILTIN2, HIGH);
+  digitalWrite(SGRBT_LED_PIN, HIGH);
 
   Wire.setPins(SGRBT_SDA_PIN, SGRBT_SCL_PIN);
   Wire.begin();
@@ -72,7 +72,7 @@ void setup() {
   delay(100);
   ble.StartAdv();
 
-  digitalWrite(LED_BUILTIN2, LOW);
+  digitalWrite(SGRBT_LED_PIN, LOW);
 }
 
 sugarboat::SensorData sensor_data{0, 0, 0, 0};
@@ -80,24 +80,7 @@ void loop() {
   bool is_realtime = config.GetRealtimeRun();
 
   imu.WakeUp();
-  // // if (!is_realtime) {
-  // //   Serial.printf("[main] Waking up IMU...\n");
-  // //   // TODO: Better strategy for waiting IMU values to converge.
-  // //   if (config.WaitForConfigChangeOrDelay(10000)) {
-  // //     return;
-  // //   }
-  // // }
-
-  // // sugarboat::IMU::Orientation orientation = imu.GetOrientation();
   sensor_data.tilt_degrees = imu.GetTilt();
-  // // Serial.printf("[main] Tilt: %.2f\n", sensor_data.tilt_degrees);
-
-  // // if (!is_realtime) {
-  // //   Serial.printf("[main] Sleeping IMU...\n");
-  // //   imu.Sleep();
-  // // }
-
-  // // ble.InjectOrientationData(orientation);
   imu.Sleep();
 
   float batt_v = 2 * 3.6f * analogRead(SGRBT_BAT_SEN_PIN) / 1024.0f;

--- a/notes.md
+++ b/notes.md
@@ -56,3 +56,7 @@
 *
 
 ### Row pitch yaw
+
+## Alternative approach
+* [Inclination sensing with accelerometer](https://www.digikey.com/en/articles/using-an-accelerometer-for-inclination-sensing) article from DigiKey
+* [LIS2DW](https://www.st.com/resource/en/datasheet/lis2dw.pdf) ultra low power accelerometer


### PR DESCRIPTION
The most important one is the dropping of MPU6050's DMP in favor of simpler, considerably more power efficient accelerometer-only mode.

In normal operation, sugarboat is almost perfectly static, floating on top of the solution. If we assume the inertial mass unit (IMU) is static, we can estimate the tilt angle by simply computing the angle between the IMU's axes and the gravity vector. This is what it's done here. 

The alternative, old approach, was to use fancy, power hungry & proprietary sensor fusion algorithms hidden inside the MPU6050. This old approach is ideal for more dynamic systems (like a real-time orientation tracking device). Besides being more power hungry, this mode is not very friendly to sleep modes - it takes some time to "converge" once woken up.

The downside of this change is that we lose the cool "real time mode" orientation tracking on the web UI. This PR also removes the "orientation" characteristic of the sensor service.